### PR TITLE
chore(worker): make execution of tasks more robust

### DIFF
--- a/lib/workers.js
+++ b/lib/workers.js
@@ -64,8 +64,13 @@ class Workers {
   }
 
   executeTask(task) {
+    const api = this.taskClient;
     const worker = this.workers[task.topicName];
-    worker.handler({ task, api: this.taskClient });
+    try {
+      worker.handler({ task, api });
+    } catch (e) {
+      console.log(e);
+    }
   }
 
   /**


### PR DESCRIPTION
It can happen that during the execution of a task an error is thrown, which is not handled by the task handler itself. With the current implementation, the `forEach` block in {{#poll()}} would be left, and other fetched and locked tasks would not be handled.