### PR TITLE
[CAM-9238/CAM-9240] feat(BPMNerror): pass vars and error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ client.subscribe("topicName", async function({ task, taskService }) {
 client.subscribe("topicName", async function({ task, taskService }) {
   // Put your business logic
   // Handle a BPMN Failure
-  await taskService.handleBpmnError(task, "BPMNError_Code");
+  await taskService.handleBpmnError(task, "BPMNError_Code", "Error message", variables);
 });
 ```
 

--- a/lib/TaskService.js
+++ b/lib/TaskService.js
@@ -86,19 +86,32 @@ class TaskService {
    * @throws Error
    * @param task
    * @param errorCode
+   * @param errorMessage
+   * @param variables
    * @returns {Promise<void>}
    */
-  async handleBpmnError(task, errorCode) {
+  async handleBpmnError(task, errorCode, errorMessage, variables) {
     if (isUndefinedOrNull(task)) {
       throw new Error(MISSING_TASK);
     }
     if (!errorCode) {
       throw new Error(MISSING_ERROR_CODE);
     }
+    if (!errorMessage) {
+      // TODO
+    }
+    if (!variables) {
+      // TODO
+    }
 
     const sanitizedTask = this.sanitizeTask(task);
     try {
-      await this.api.handleBpmnError(sanitizedTask, errorCode);
+      await this.api.handleBpmnError(
+        sanitizedTask,
+        errorCode,
+        errorMessage,
+        variables
+      );
       this.success("handleBpmnError", task);
     } catch (e) {
       this.error("handleBpmnError", task, e);

--- a/lib/TaskService.test.js
+++ b/lib/TaskService.test.js
@@ -186,6 +186,7 @@ describe("TaskService", () => {
       expect(sanitizeTaskSpy).toBeCalledWith(expectedTaskId);
     });
 
+    /* TODO
     test("should call api handleBpmnError with provided task and error code", () => {
       //given
       const handleBpmnErrorSpy = jest.spyOn(engineService, "handleBpmnError");
@@ -199,6 +200,39 @@ describe("TaskService", () => {
       expect(handleBpmnErrorSpy).toBeCalledWith(
         { id: expectedTaskId },
         expectedErrorCode
+      );
+    }); */
+
+    test("should call api handleBpmnError with provided task, error code, error message and variables", () => {
+      //given
+      const handleBpmnErrorSpy = jest.spyOn(engineService, "handleBpmnError");
+      const expectedTaskId = "foo";
+      const expectedErrorCode = "foo123";
+      const expectedErrorMessage = "errMess";
+      const expectedVariables = {
+        someVariable: {
+          value: "some variable value",
+          type: "string",
+          valueInfo: {}
+        }
+      };
+      const variables = new Variables();
+      variables.setAllTyped(expectedVariables);
+
+      //when
+      taskService.handleBpmnError(
+        expectedTaskId,
+        expectedErrorCode,
+        expectedErrorMessage,
+        variables
+      );
+
+      //then
+      expect(handleBpmnErrorSpy).toBeCalledWith(
+        { id: expectedTaskId },
+        expectedErrorCode,
+        expectedErrorMessage,
+        variables
       );
     });
   });

--- a/lib/__internal/EngineService.js
+++ b/lib/__internal/EngineService.js
@@ -97,12 +97,14 @@ class EngineService {
    * @throws HTTPError
    * @param id
    * @param errorCode
+   * @param errorMessage
+   * @param variables
    * @returns {Promise}
    */
-  handleBpmnError({ id }, errorCode) {
+  handleBpmnError({ id }, errorCode, errorMessage, variables) {
     return this.post(`/external-task/${id}/bpmnError`, {
       json: true,
-      body: { errorCode, workerId: this.workerId }
+      body: { errorCode, workerId: this.workerId, errorMessage, variables }
     });
   }
 

--- a/lib/__internal/EngineService.test.js
+++ b/lib/__internal/EngineService.test.js
@@ -105,13 +105,22 @@ describe("EngineService", () => {
     const expectedTaskId = "foo";
     const expectedUrl = `/external-task/${expectedTaskId}/bpmnError`;
     const expectedErrorCode = "some error code";
+    const expectedErrorMessage = "some error message";
     const expectedPayload = {
       json: true,
-      body: { errorCode: expectedErrorCode, workerId: engineService.workerId }
+      body: {
+        errorCode: expectedErrorCode,
+        errorMessage: expectedErrorMessage,
+        workerId: engineService.workerId
+      }
     };
 
     // when
-    engineService.handleBpmnError({ id: expectedTaskId }, expectedErrorCode);
+    engineService.handleBpmnError(
+      { id: expectedTaskId },
+      expectedErrorCode,
+      expectedErrorMessage
+    );
 
     // then
     expect(postSpy).toBeCalledWith(expectedUrl, expectedPayload);


### PR DESCRIPTION
Hi guys,

This is my work in progress for CAM-9238/CAM-9240
I could achieve backwards compatibility so that the previous 
```javascript
handleBpmnError(task, errorCode)
```
to work.
Please note that `errorMessage` and `variables` are optional.

Best regards,
Yana