### PR TITLE
WIP: Modify Client to execute tasks async and separate topics

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -50,6 +50,7 @@ class Client extends events {
     this.sanitizeOptions = this.sanitizeOptions.bind(this);
     this.start = this.start.bind(this);
     this.poll = this.poll.bind(this);
+    this.setupPoll = this.setupPoll.bind(this);
     this.subscribe = this.subscribe.bind(this);
     this.executeTask = this.executeTask.bind(this);
     this.stop = this.stop.bind(this);
@@ -116,13 +117,13 @@ class Client extends events {
    */
   start() {
     this._isPollAllowed = true;
-    this.poll();
+    this.setupPoll();
   }
 
   /**
    * Polls tasks from engine and executes them
    */
-  async poll() {
+  async setupPoll() {
     if (!this._isPollAllowed) {
       return;
     }
@@ -140,7 +141,7 @@ class Client extends events {
 
     // if there are no topic subscriptions, reschedule polling
     if (!Object.keys(topicSubscriptions).length) {
-      return setTimeout(this.poll, interval);
+      return setTimeout(this.setupPoll, interval);
     }
 
     // collect topics that have subscriptions
@@ -160,16 +161,23 @@ class Client extends events {
       }
     );
 
-    const requestBody = { ...pollingOptions, topics };
+    topics.forEach((topic) => {
+      poll(pollingOptions, topic, interval);
+    });  
+  }
 
+  async poll(pollingOptions, topic, interval) {
+    const { engineService, executeTask, poll } = this;
+    const requestBody = { ...pollingOptions, topics: [ topic ] };
     try {
       const tasks = await engineService.fetchAndLock(requestBody);
+      setTimeout(() => poll(pollingOptions, topic, interval), interval);
       this.emit("poll:success", tasks);
       tasks.forEach(executeTask);
     } catch (e) {
       this.emit("poll:error", e);
+      setTimeout(() => poll(pollingOptions, topic, interval), interval);
     }
-    setTimeout(poll, interval);
   }
 
   /**
@@ -218,20 +226,24 @@ class Client extends events {
    * Executes task using the worker registered to its topic
    */
   executeTask(task) {
-    const taskService = this.taskService;
-    const topicSubscription = this.topicSubscriptions[task.topicName];
-    const variables = new Variables(task.variables, {
-      readOnly: true,
-      processInstanceId: task.processInstanceId,
-      engineService: this.engineService
-    });
-    const newTask = { ...task, variables };
-    try {
-      topicSubscription.handler({ task: newTask, taskService });
-      this.emit("handler:success", task);
-    } catch (e) {
-      this.emit("handler:error", e);
-    }
+    return new Promise((resolve, reject) => {
+      const taskService = this.taskService;
+      const topicSubscription = this.topicSubscriptions[task.topicName];
+      const variables = new Variables(task.variables, {
+        readOnly: true,
+        processInstanceId: task.processInstanceId,
+        engineService: this.engineService
+      });
+      const newTask = { ...task, variables };
+      try {
+        topicSubscription.handler({ task: newTask, taskService });
+        this.emit("handler:success", task);
+        return resolve(task);
+      } catch (e) {
+        this.emit("handler:error", e);
+        return reject(e)
+      }
+    })
   }
 
   /**


### PR DESCRIPTION
This PR is related to issue [15](https://github.com/camunda/camunda-external-task-client-js/issues/15).

The idea is to launch one `poll()` method per topic and trigger task execution asynchronously. The main benefit is that reduces latency and topics competition. 

Tests pending.