### PR TITLE
[CAM-10614] handle `deserializeValues` option on subscribe

### DIFF
--- a/docs/Client.md
+++ b/docs/Client.md
@@ -71,7 +71,7 @@ The currently supported options are:
 | processDefinitionKeyIn  | A value which allows to filter tasks based on process definition keys         | string |          |                                                       |
 | withoutTenantId  | A value which allows to filter tasks based on tenant ids         | string |          |                                                       |
 | tenantIdIn   | A value which allows to filter tasks without tenant id                              | boolean |         |                                                       |
-
+| deserializeValues | If set to true, a serializable variable will be deserialized on server side and transformed to JSON using Jackson's POJO/bean property introspection feature. | boolean |                                                       |     
 
 ### About topic subscriptions
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -188,7 +188,8 @@ class Client extends events {
           processDefinitionKey,
           processDefinitionKeyIn,
           tenantIdIn,
-          withoutTenantId
+          withoutTenantId,
+          deserializeValues
         }
       ]) => {
         let topic = { topicName, lockDuration };
@@ -223,6 +224,10 @@ class Client extends events {
 
         if (!isUndefinedOrNull(withoutTenantId)) {
           topic.withoutTenantId = withoutTenantId;
+        }
+
+        if (!isUndefinedOrNull(deserializeValues)) {
+          topic.deserializeValues = deserializeValues;
         }
 
         return topic;

--- a/lib/Client.test.js
+++ b/lib/Client.test.js
@@ -193,7 +193,8 @@ describe("Client", () => {
         processDefinitionKey: "processKey",
         processDefinitionKeyIn: ["processKey", "processKey2"],
         tenantIdIn: ["tenantId"],
-        withoutTenantId: true
+        withoutTenantId: true,
+        deserializeValues: true
       };
     });
 
@@ -310,6 +311,19 @@ describe("Client", () => {
       // then
       expect(footopicSubscription.withoutTenantId).toBe(
         customConfig.withoutTenantId
+      );
+    });
+
+    test("should subscribe to topic based on deserializeValues ", () => {
+      // given
+      const footopicSubscription = client.subscribe(
+        "foo",
+        customConfig,
+        fooWork
+      );
+      // then
+      expect(footopicSubscription.deserializeValues).toBe(
+        customConfig.deserializeValues
       );
     });
 

--- a/lib/__snapshots__/Client.test.js.snap
+++ b/lib/__snapshots__/Client.test.js.snap
@@ -27,6 +27,7 @@ Array [
     "maxTasks": 3,
     "topics": Array [
       Object {
+        "deserializeValues": true,
         "lockDuration": 3000,
         "processDefinitionId": "processId",
         "processDefinitionIdIn": Array [


### PR DESCRIPTION
`deserializeValues`  option seems not to be handled yet. 
Here is my first humble contribution to this awesome bpm engine.

Note that this is just an option for function `subscribe`.
Example: 
```
client.subscribe(
  'mytopic',
  { deserializeValues: true },
  async ({ task, taskService }) => { /* */ },
)```