### PR TITLE
CAM-11162: Added 'processVariables' property to fetchAndLock request object

### DIFF
--- a/docs/Client.md
+++ b/docs/Client.md
@@ -71,7 +71,8 @@ The currently supported options are:
 | processDefinitionIdIn  | A value which allows to filter tasks based on process definition ids         | string |          |                                                       |
 | processDefinitionKey  | A value which allows to filter tasks based on process definition key         | string |          |                                                       |
 | processDefinitionKeyIn  | A value which allows to filter tasks based on process definition keys         | string |          |                                                       |
-| processDefinitionVersionTag  | A value which allows to filter tasks based on process definition Version Tag         | string |          |                                                       |
+| processDefinitionVersionTag  | A value which allows to filter tasks based on process definition Version Tag         | string |          |
+| processVariables  | A JSON object used for filtering tasks based on process instance variable values. A property name of the object represents a process variable name, while the property value represents the process variable value to filter tasks by.         | object |          |                                                       |
 | tenantIdIn | A value which allows to filter tasks based on tenant ids         | string |          |                                                       |
 | withoutTenantId | A value which allows to filter tasks without tenant id                              | boolean |         |                                                       |
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -193,6 +193,7 @@ class Client extends events {
           processDefinitionKey,
           processDefinitionKeyIn,
           processDefinitionVersionTag,
+          processVariables,
           tenantIdIn,
           withoutTenantId
         }
@@ -225,6 +226,10 @@ class Client extends events {
 
         if (!isUndefinedOrNull(processDefinitionVersionTag)) {
           topic.processDefinitionVersionTag = processDefinitionVersionTag;
+        }
+
+        if (!isUndefinedOrNull(processVariables)) {
+          topic.processVariables = processVariables;
         }
 
         if (!isUndefinedOrNull(tenantIdIn)) {


### PR DESCRIPTION
[![CAM-11162](https://badgen.net/badge/JIRA/CAM-11162/0052CC)](https://app.camunda.com/jira/browse/CAM-11162)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

In the latest Camunda version, there is a possibility to filter out the tasks that need to be fetched by specifying the values of the process variables: https://docs.camunda.org/manual/latest/reference/rest/external-task/fetch/

There is no such property in the request configuration object, so this property was added in this commit.