### PR TITLE
[CAM-11670] feat(auth): add keycloak auth interceptor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ tmp/
 docs/api/
 dist/
 .idea
-*.imls
+*.iml
 coverage/

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ client.subscribe("topicName", async function({ task, taskService }) {
   * [File Properties](https://github.com/camunda/camunda-external-task-client-js/blob/master/docs/File.md#file-properties)
 * [BasicAuthInterceptor](https://github.com/camunda/camunda-external-task-client-js/blob/master/docs/BasicAuthInterceptor.md)
   * [new BasicAuthInterceptor(options)](https://github.com/camunda/camunda-external-task-client-js/blob/master/docs/BasicAuthInterceptor.md#new-basicauthinterceptoroptions)
+* [KeycloakAuthInterceptor](https://github.com/camunda/camunda-external-task-client-js/blob/master/docs/KeycloakAuthInterceptor.md)
+  * [new KeycloakAuthInterceptor(options)](https://github.com/camunda/camunda-external-task-client-js/blob/master/docs/KeycloakAuthInterceptor.md#new-keycloakauthinterceptoroptions)
 * [logger](https://github.com/camunda/camunda-external-task-client-js/blob/master/docs/logger.md)
   * [logger.success(text)](https://github.com/camunda/camunda-external-task-client-js/blob/master/docs/logger.md#loggersuccesstext)
   * [logger.error(text)](https://github.com/camunda/camunda-external-task-client-js/blob/master/docs/logger.md#loggererrortext)

--- a/__mocks__/got.js
+++ b/__mocks__/got.js
@@ -15,17 +15,24 @@
  * limitations under the License.
  */
 
-const handleRequest = (url, { errorType, error }) => {
-  switch (errorType) {
-    case "FAIL_WITHOUT_RESPONSE":
-    case "FAIL_WITH_RESPONSE":
-      return Promise.reject(error);
-    default:
-      return Promise.resolve({ body: [] });
+const got = jest.requireActual('got');
+
+const handleRequest = (url, { testResult }) => {
+  return {
+    json: () => {
+      if (testResult instanceof Error) {
+        return Promise.reject(testResult);
+      }
+
+      return Promise.resolve(testResult);
+    }
   }
 };
 
-const got = handleRequest;
-got.post = got.get = handleRequest;
+const gotMock = handleRequest;
+gotMock.json = () => {};
 
-module.exports = jest.fn().mockImplementation(got);
+const myModule = module.exports = jest.fn().mockImplementation(gotMock);
+myModule.GotError = got.GotError;
+myModule.HTTPError = got.HTTPError;
+myModule.RequestError = got.RequestError;

--- a/docs/KeycloakAuthInterceptor.md
+++ b/docs/KeycloakAuthInterceptor.md
@@ -1,0 +1,48 @@
+# KeycloakAuthInterceptor
+
+A KeycloakAuthInterceptor instance is an interceptor that adds a Bearer token header, containing 
+a [Keycloak](https://www.keycloak.org/) access token, to all requests. This interceptor can be used
+if the Camunda REST API is protected with [Keycloak Gatekeeper](https://github.com/keycloak/keycloak-gatekeeper).
+
+This client serves also as an example for OpenID Connect based authentication. It shows also how an interceptor
+with async functionality can be implemented with [hooks](https://github.com/sindresorhus/got#hooks), which are 
+provided by the underlying [got](https://github.com/sindresorhus/got) HTTP request library. 
+
+```js
+const {
+  Client,
+  KeycloakAuthInterceptor
+} = require("camunda-external-task-client-js");
+
+const keycloakAuthentication = new KeycloakAuthInterceptor({
+  tokenEndpoint: "https://your.keyclock.domain/realms/your-realm/protocol/openid-connect/token",
+  clientId: "your-client-id",
+  clientSecret: "your-client-secret"
+});
+
+const client = new Client({
+  baseUrl: "http://localhost:8080/engine-rest",
+  interceptors: keycloakAuthentication
+});
+```
+
+## Caching
+
+The Keycloak access token has an expiry defined. To reduce the requests to the token endpoint, we cache the token 
+response as long it is valid.
+
+To poll the API always with a valid token, we subtract the `cacheOffset` from the validity. If the token is 60 seconds
+valid and we poll the API every 5 seconds, there could be the case that we poll the API exactly at the time the token 
+expires. The default `cacheOffset` from 10 seconds is a good balance between the token validity and the average request 
+duration.
+
+## new KeycloakAuthInterceptor(options)
+
+Here's a list of the available options:
+
+| Option        | Description                           | Type   | Required | Default |
+| ------------- | ------------------------------------- | ------ | -------- | ------- |
+| tokenEndpoint | URL to the Keycloak token endpoint    | string | ✓        |         |
+| clientId      | The Keycloak client id                | string | ✓        |         |
+| clientSecret  | The Keycloak client secret            | string | ✓        |         |
+| cacheOffset   | The time in seconds to subtract from the token expiry | number |          | 10      |

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = {
   Client: require("./lib/Client"),
   logger: require("./lib/logger"),
   BasicAuthInterceptor: require("./lib/BasicAuthInterceptor"),
+  KeycloakAuthInterceptor: require("./lib/KeycloakAuthInterceptor"),
   Variables: require("./lib/Variables"),
   File: require("./lib/File")
 };

--- a/lib/BasicAuthInterceptor.js
+++ b/lib/BasicAuthInterceptor.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-const { MISSING_AUTH_PARAMS } = require("./__internal/errors");
+const { MISSING_BASIC_AUTH_PARAMS } = require("./__internal/errors");
 
 class BasicAuthInterceptor {
   /**
@@ -23,7 +23,7 @@ class BasicAuthInterceptor {
    */
   constructor(options) {
     if (!options || !options.username || !options.password) {
-      throw new Error(MISSING_AUTH_PARAMS);
+      throw new Error(MISSING_BASIC_AUTH_PARAMS);
     }
 
     /**
@@ -38,7 +38,7 @@ class BasicAuthInterceptor {
   }
 
   getHeader({ username, password }) {
-    const encoded = new Buffer(`${username}:${password}`).toString("base64");
+    const encoded = Buffer.from(`${username}:${password}`).toString("base64");
     return { Authorization: `Basic ${encoded}` };
   }
 

--- a/lib/BasicAuthInterceptor.test.js
+++ b/lib/BasicAuthInterceptor.test.js
@@ -16,17 +16,19 @@
  */
 
 const BasicAuthInterceptor = require("./BasicAuthInterceptor");
-const { MISSING_AUTH_PARAMS } = require("./__internal/errors");
+const { MISSING_BASIC_AUTH_PARAMS } = require("./__internal/errors");
 
 describe("BasicAuthInterceptor", () => {
   test("should throw error if username or password are missing", () => {
-    expect(() => new BasicAuthInterceptor()).toThrowError(MISSING_AUTH_PARAMS);
+    expect(() => new BasicAuthInterceptor()).toThrowError(
+      MISSING_BASIC_AUTH_PARAMS
+    );
     expect(
       () => new BasicAuthInterceptor({ username: "some username" })
-    ).toThrowError(MISSING_AUTH_PARAMS);
+    ).toThrowError(MISSING_BASIC_AUTH_PARAMS);
     expect(
       () => new BasicAuthInterceptor({ password: "some password" })
-    ).toThrowError(MISSING_AUTH_PARAMS);
+    ).toThrowError(MISSING_BASIC_AUTH_PARAMS);
   });
 
   test("should add basic auth header to intercepted config", () => {

--- a/lib/KeycloakAuthInterceptor.js
+++ b/lib/KeycloakAuthInterceptor.js
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const got = require("got");
+const {
+  MISSING_KEYCLOAK_AUTH_PARAMS,
+  UNEXPECTED_KEYCLOAK_TOKEN_RESULT
+} = require("./__internal/errors");
+
+/**
+ * A KeycloakAuthInterceptor instance is an interceptor that adds a Bearer token header, containing
+ * a access token, to all requests. This interceptor can be used if the Camunda REST API is protected with
+ * Keycloak Gatekeeper.
+ */
+class KeycloakAuthInterceptor {
+  /**
+   * The class constructor.
+   *
+   * @param options The Keycloak auth interceptor options.
+   * @returns function(*): {hooks: {beforeRequest: [function(*): Promise<void>]}} The interceptor function.
+   * @throws Error if the required options are not set.
+   */
+  constructor(options) {
+    if (
+      !options ||
+      !options.tokenEndpoint ||
+      !options.clientId ||
+      !options.clientSecret
+    ) {
+      throw new Error(MISSING_KEYCLOAK_AUTH_PARAMS);
+    }
+
+    /**
+     * Bind member methods
+     */
+    this.getAccessToken = this.getAccessToken.bind(this);
+    this.cacheToken = this.cacheToken.bind(this);
+    this.interceptor = this.interceptor.bind(this);
+
+    this.cacheOffset =
+      options.cacheOffset !== undefined ? options.cacheOffset : 10;
+    this.tokenEndpoint = options.tokenEndpoint;
+    this.clientId = options.clientId;
+    this.clientSecret = options.clientSecret;
+
+    return this.interceptor;
+  }
+
+  /**
+   * Requests a new access token from the Keycloak endpoint.
+   *
+   * @param tokenEndpoint The URL to the Keycloak token endpoint.
+   * @param clientID      The Keycloak client ID.
+   * @param clientSecret  The Keycloak client secret.
+   * @returns {Promise<{access_token: String, expires_in: Number}>} The token response, containing the access token and
+   * it's expiry in seconds.
+   * @throws Error if an error occurred during the request.
+   */
+  async getAccessToken(tokenEndpoint, clientID, clientSecret) {
+    const credentials = Buffer.from(`${clientID}:${clientSecret}`).toString(
+      "base64"
+    );
+
+    try {
+      return await got(tokenEndpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Authorization: `Basic: ${credentials}`
+        },
+        body: "grant_type=client_credentials"
+      }).json();
+    } catch (e) {
+      throw new Error(
+        `${UNEXPECTED_KEYCLOAK_TOKEN_RESULT} status: ${e.response.statusCode}; body: ${e.response.body}`
+      );
+    }
+  }
+
+  /**
+   * The Keycloak access token has an expiry defined. To reduce the requests to the token endpoint, we
+   * cache the token response as long it is valid.
+   *
+   * To poll the API always with a valid token, we subtract the `cacheOffset` from the validity. If the token is 60
+   * seconds valid and we poll the API every 5 seconds, there could be the case that we poll the API exactly at the
+   * time the token expires. The default `cacheOffset` from 10 seconds is a good balance between the token validity
+   * and the average request duration.
+   *
+   * If the `expires_in` property wasn't set or if the validity is less than or equal the `cacheOffset`, we don't
+   * cache the token.
+   *
+   * @param {{access_token: String, expires_in: Number}} token The token response.
+   */
+  cacheToken(token) {
+    const expiresIn = token.expires_in || 0;
+
+    if (expiresIn > this.cacheOffset) {
+      this.tokenCache = token;
+      const tokenCleaner = () => {
+        this.tokenCache = null;
+      };
+      setTimeout(
+        tokenCleaner.bind(this),
+        (expiresIn - this.cacheOffset) * 1000
+      );
+    }
+  }
+
+  /**
+   * The interceptor function that enriches the `got` request with the access token hook.
+   *
+   * @param config The `got` request config.
+   * @returns {{hooks: {beforeRequest: [function(*): Promise<void>]}}} The `got` config containing the access
+   * token hook.
+   */
+  interceptor(config) {
+    // https://www.npmjs.com/package/got#hooksbeforerequest
+    const hooks = {
+      beforeRequest: [
+        async options => {
+          let token = this.tokenCache;
+          if (!token) {
+            token = await this.getAccessToken(
+              this.tokenEndpoint,
+              this.clientId,
+              this.clientSecret
+            );
+            this.cacheToken(token);
+          }
+
+          if (token && token.access_token) {
+            const defaultHeaders = options.headers || {};
+            const headers = {
+              Authorization: `Bearer ${token.access_token}`
+            };
+
+            options.headers = { ...defaultHeaders, ...headers };
+          } else {
+            throw new Error(
+              `${UNEXPECTED_KEYCLOAK_TOKEN_RESULT} token without access_token property: ${JSON.stringify(
+                token
+              )}`
+            );
+          }
+        }
+      ]
+    };
+
+    return { ...config, hooks: { ...config.hooks, ...hooks } };
+  }
+}
+
+module.exports = KeycloakAuthInterceptor;

--- a/lib/KeycloakAuthInterceptor.test.js
+++ b/lib/KeycloakAuthInterceptor.test.js
@@ -1,0 +1,216 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const got = require("got");
+const KeycloakAuthInterceptor = require("./KeycloakAuthInterceptor");
+const {
+  MISSING_KEYCLOAK_AUTH_PARAMS,
+  UNEXPECTED_KEYCLOAK_TOKEN_RESULT
+} = require("./__internal/errors");
+
+describe("KeycloakAuthInterceptor", () => {
+  afterEach(() => {
+    got.mockClear();
+  });
+
+  test("should throw error if tokenEndpoint, clientId or clientSecret are missing", () => {
+    expect(() => new KeycloakAuthInterceptor()).toThrowError(
+      MISSING_KEYCLOAK_AUTH_PARAMS
+    );
+    expect(
+      () => new KeycloakAuthInterceptor({ tokenEndpoint: "some endpoint" })
+    ).toThrowError(MISSING_KEYCLOAK_AUTH_PARAMS);
+    expect(
+      () => new KeycloakAuthInterceptor({ clientId: "some id" })
+    ).toThrowError(MISSING_KEYCLOAK_AUTH_PARAMS);
+    expect(
+      () => new KeycloakAuthInterceptor({ clientSecret: "some secret" })
+    ).toThrowError(MISSING_KEYCLOAK_AUTH_PARAMS);
+    expect(
+      () =>
+        new KeycloakAuthInterceptor({
+          tokenEndpoint: "some endpoint",
+          clientId: "some id"
+        })
+    ).toThrowError(MISSING_KEYCLOAK_AUTH_PARAMS);
+    expect(
+      () =>
+        new KeycloakAuthInterceptor({
+          tokenEndpoint: "some endpoint",
+          clientSecret: "some secret"
+        })
+    ).toThrowError(MISSING_KEYCLOAK_AUTH_PARAMS);
+    expect(
+      () =>
+        new KeycloakAuthInterceptor({
+          clientId: "some password",
+          clientSecret: "some secret"
+        })
+    ).toThrowError(MISSING_KEYCLOAK_AUTH_PARAMS);
+  });
+
+  test("should throw error if token endpoint returns unexpected HTTP response", async () => {
+    // given
+    got.mockReturnValue({
+      json: () =>
+        Promise.reject(
+          new got.HTTPError(
+            {
+              body: "Some keycloak error",
+              statusCode: 400,
+              statusMessage: "Bad request"
+            },
+            {}
+          )
+        )
+    });
+    const keycloakAuthInterceptor = new KeycloakAuthInterceptor({
+      tokenEndpoint: "some endpoint",
+      clientId: "some id",
+      clientSecret: "some secret"
+    });
+
+    // when
+    const { hooks } = keycloakAuthInterceptor({});
+    const hook = hooks.beforeRequest[0];
+
+    // then
+    try {
+      await hook({});
+    } catch (e) {
+      expect(e).toEqual(
+        new Error(
+          `${UNEXPECTED_KEYCLOAK_TOKEN_RESULT} status: 400; body: Some keycloak error`
+        )
+      );
+    }
+  });
+
+  test("should throw error if token doesn't contains the access token", async () => {
+    // given
+    got.mockReturnValue({ json: () => Promise.resolve({}) });
+    const keycloakAuthInterceptor = new KeycloakAuthInterceptor({
+      tokenEndpoint: "some endpoint",
+      clientId: "some id",
+      clientSecret: "some secret"
+    });
+
+    // when
+    const { hooks } = keycloakAuthInterceptor({});
+    const hook = hooks.beforeRequest[0];
+
+    // then
+    try {
+      await hook({});
+    } catch (e) {
+      expect(e).toEqual(
+        new Error(
+          `${UNEXPECTED_KEYCLOAK_TOKEN_RESULT} token without access_token property: {}`
+        )
+      );
+    }
+  });
+
+  test("should add auth token to intercepted config", async () => {
+    // given
+    got.mockReturnValue({
+      json: () => Promise.resolve({ access_token: "1234567890" })
+    });
+    const keycloakAuthInterceptor = new KeycloakAuthInterceptor({
+      tokenEndpoint: "some endpoint",
+      clientId: "some id",
+      clientSecret: "some secret"
+    });
+    const options = { key: "some value" };
+
+    // when
+    const { hooks } = keycloakAuthInterceptor({});
+    const hook = hooks.beforeRequest[0];
+    await hook(options);
+
+    //then
+    expect(options).toMatchSnapshot();
+  });
+
+  test("should cache the token response if token expiry is greater than cacheOffset", async () => {
+    // given
+    const tokenResponse = { access_token: "1234567890", expires_in: 5 };
+    got.mockReturnValue({ json: () => Promise.resolve(tokenResponse) });
+    const keycloakAuthInterceptor = new KeycloakAuthInterceptor({
+      tokenEndpoint: "some endpoint",
+      clientId: "some id",
+      clientSecret: "some secret",
+      cacheOffset: 0
+    });
+
+    // when
+    const { hooks } = keycloakAuthInterceptor({});
+    const hook = hooks.beforeRequest[0];
+    await hook({});
+    await hook({});
+
+    //then
+    expect(got).toHaveBeenCalledTimes(1);
+  });
+
+  test("should not cache the token response if token expiry is less than cacheOffset", async () => {
+    // given
+    const tokenResponse = { access_token: "1234567890", expires_in: 5 };
+    got.mockReturnValue({ json: () => Promise.resolve(tokenResponse) });
+    const keycloakAuthInterceptor = new KeycloakAuthInterceptor({
+      tokenEndpoint: "some endpoint",
+      clientId: "some id",
+      clientSecret: "some secret",
+      cacheOffset: 10
+    });
+
+    // when
+    const { hooks } = keycloakAuthInterceptor({});
+    const hook = hooks.beforeRequest[0];
+    await hook({});
+    await hook({});
+
+    //then
+    expect(got).toHaveBeenCalledTimes(2);
+  });
+
+  test("should clear the token cache", async () => {
+    jest.useFakeTimers();
+
+    // given
+    const tokenResponse = { access_token: "1234567890", expires_in: 5 };
+    got.mockReturnValue({ json: () => Promise.resolve(tokenResponse) });
+    const keycloakAuthInterceptor = new KeycloakAuthInterceptor({
+      tokenEndpoint: "some endpoint",
+      clientId: "some id",
+      clientSecret: "some secret",
+      cacheOffset: 0
+    });
+
+    // when
+    const { hooks } = keycloakAuthInterceptor({});
+    const hook = hooks.beforeRequest[0];
+    await hook({});
+    jest.runAllTimers();
+    await hook({});
+
+    //then
+    expect(got).toHaveBeenCalledTimes(2);
+
+    jest.useRealTimers();
+  });
+});

--- a/lib/__internal/EngineError.js
+++ b/lib/__internal/EngineError.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { GotError } = require("got");
+
+/**
+ * An error that contains the error from the Camunda REST API as also the HTTP error details like the status code
+ * and status message.
+ *
+ * If a non 2xx status code occurs, got will throw a `got.HTTPError` that contains the error response from the engine.
+ * This error isn't extendable, because it sets the error message in the constructor. Therefore we inherit from the
+ * got base error type (`got.GotError`), copy the logic form the `got.HTTPError` class and extend it with our API
+ * response message.
+ *
+ * @see https://docs.camunda.org/manual/latest/reference/rest/overview/#error-handling
+ */
+class EngineError extends GotError {
+  constructor(httpError) {
+    const { response, options } = httpError;
+    let error, type;
+
+    if (response.body && response.body.message && response.body.type) {
+      error = response.body.message;
+      type = response.body.type;
+    } else {
+      error = response.body;
+      type = "undefined";
+    }
+
+    super(
+      `Response code ${response.statusCode} (${response.statusMessage}); Error: ${error}; Type: ${type}`,
+      {},
+      options
+    );
+    this.name = "EngineError";
+
+    Object.defineProperty(this, "response", {
+      enumerable: false,
+      value: response
+    });
+  }
+}
+
+module.exports = EngineError;

--- a/lib/__internal/EngineError.test.js
+++ b/lib/__internal/EngineError.test.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const got = require("got");
+const EngineError = require("./EngineError");
+
+describe("EngineError", () => {
+  test("construct an error from a Camunda REST API error", () => {
+    //given
+    const httpError = new got.HTTPError(
+      {
+        body: { type: "SomeExceptionClass", message: "a detailed message" },
+        statusCode: 400,
+        statusMessage: "Bad request"
+      },
+      {}
+    );
+    const expectedPayload =
+      "Response code 400 (Bad request); Error: a detailed message; Type: SomeExceptionClass";
+
+    //when
+    const engineError = new EngineError(httpError);
+
+    //then
+    expect(engineError.message).toEqual(expectedPayload);
+  });
+
+  test("construct an error with an unexpected response body", () => {
+    //given
+    const httpError = new got.HTTPError(
+      {
+        body: "Some unexpected error message",
+        statusCode: 400,
+        statusMessage: "Bad request"
+      },
+      {}
+    );
+    const expectedPayload =
+      "Response code 400 (Bad request); Error: Some unexpected error message; Type: undefined";
+
+    //when
+    const engineError = new EngineError(httpError);
+
+    //then
+    expect(engineError.message).toEqual(expectedPayload);
+  });
+});

--- a/lib/__internal/EngineService.js
+++ b/lib/__internal/EngineService.js
@@ -16,6 +16,7 @@
  */
 
 const got = require("got");
+const EngineError = require("./EngineError");
 
 class EngineService {
   constructor({ workerId, baseUrl, interceptors }) {
@@ -45,10 +46,13 @@ class EngineService {
     }
 
     try {
-      const { body } = await got(url, newOptions);
-      return body;
+      return await got(url, newOptions).json();
     } catch (e) {
-      throw e.response ? e.response.body.message : e;
+      if (e instanceof got.HTTPError) {
+        throw new EngineError(e);
+      }
+
+      throw e;
     }
   }
 
@@ -79,8 +83,7 @@ class EngineService {
    */
   fetchAndLock(requestBody) {
     return this.post("/external-task/fetchAndLock", {
-      json: true,
-      body: { ...requestBody, workerId: this.workerId }
+      json: { ...requestBody, workerId: this.workerId }
     });
   }
 
@@ -88,12 +91,12 @@ class EngineService {
    * @throws HTTPError
    * @param id
    * @param variables
+   * @param localVariables
    * @returns {Promise}
    */
   complete({ id, variables, localVariables }) {
     return this.post(`/external-task/${id}/complete`, {
-      json: true,
-      body: { workerId: this.workerId, variables, localVariables }
+      json: { workerId: this.workerId, variables, localVariables }
     });
   }
 
@@ -105,8 +108,7 @@ class EngineService {
    */
   handleFailure({ id }, options) {
     return this.post(`/external-task/${id}/failure`, {
-      json: true,
-      body: { ...options, workerId: this.workerId }
+      json: { ...options, workerId: this.workerId }
     });
   }
 
@@ -120,8 +122,7 @@ class EngineService {
    */
   handleBpmnError({ id }, errorCode, errorMessage, variables) {
     return this.post(`/external-task/${id}/bpmnError`, {
-      json: true,
-      body: { errorCode, workerId: this.workerId, errorMessage, variables }
+      json: { errorCode, workerId: this.workerId, errorMessage, variables }
     });
   }
 
@@ -133,8 +134,7 @@ class EngineService {
    */
   extendLock({ id }, newDuration) {
     return this.post(`/external-task/${id}/extendLock`, {
-      json: true,
-      body: { newDuration, workerId: this.workerId }
+      json: { newDuration, workerId: this.workerId }
     });
   }
 
@@ -144,7 +144,7 @@ class EngineService {
    * @returns {Promise}
    */
   unlock({ id }) {
-    return this.post(`/external-task/${id}/unlock`, { json: true });
+    return this.post(`/external-task/${id}/unlock`, {});
   }
 }
 

--- a/lib/__internal/EngineService.test.js
+++ b/lib/__internal/EngineService.test.js
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 
-jest.mock("got");
-
 const got = require("got");
 
 const EngineService = require("./EngineService");
+const EngineError = require("./EngineError");
 
 describe("EngineService", () => {
   let engineService, postSpy, requestSpy;
@@ -61,8 +60,7 @@ describe("EngineService", () => {
     const expectedUrl = "/external-task/fetchAndLock";
     const expectedReqBody = { someKey: "some value" };
     const expectedPayload = {
-      json: true,
-      body: { ...expectedReqBody, workerId: engineService.workerId }
+      json: { ...expectedReqBody, workerId: engineService.workerId }
     };
 
     // when
@@ -81,8 +79,7 @@ describe("EngineService", () => {
       someLocalVariable: "some local variable value"
     };
     const expectedPayload = {
-      json: true,
-      body: {
+      json: {
         workerId: engineService.workerId,
         variables: expectedVariables,
         localVariables: expectedLocalVariables
@@ -106,8 +103,7 @@ describe("EngineService", () => {
     const expectedUrl = `/external-task/${expectedTaskId}/failure`;
     const expectedRequestBody = { errorMessage: "some error message" };
     const expectedPayload = {
-      json: true,
-      body: { ...expectedRequestBody, workerId: engineService.workerId }
+      json: { ...expectedRequestBody, workerId: engineService.workerId }
     };
 
     // when
@@ -124,8 +120,7 @@ describe("EngineService", () => {
     const expectedErrorCode = "some error code";
     const expectedErrorMessage = "some error message";
     const expectedPayload = {
-      json: true,
-      body: {
+      json: {
         errorCode: expectedErrorCode,
         errorMessage: expectedErrorMessage,
         workerId: engineService.workerId
@@ -149,8 +144,7 @@ describe("EngineService", () => {
     const expectedUrl = `/external-task/${expectedTaskId}/extendLock`;
     const expectedNewDuration = 100;
     const expectedPayload = {
-      json: true,
-      body: {
+      json: {
         newDuration: expectedNewDuration,
         workerId: engineService.workerId
       }
@@ -167,7 +161,7 @@ describe("EngineService", () => {
     // given
     const expectedTaskId = "foo";
     const expectedUrl = `/external-task/${expectedTaskId}/unlock`;
-    const expectedPayload = { json: true };
+    const expectedPayload = {};
 
     // when
     engineService.unlock({ id: expectedTaskId });
@@ -177,7 +171,6 @@ describe("EngineService", () => {
   });
 
   describe("request", () => {
-    jest.mock("got", () => jest.fn());
     it("should send request with given options", () => {
       //given
       const method = "POST";
@@ -225,42 +218,43 @@ describe("EngineService", () => {
       expect(got).toBeCalledWith(expectedUrl, expectedPayload);
     });
 
-    it("should throw error if request fails without response", async () => {
+    it("should throw error if request fails with HTTPError", async () => {
       // given
-      const errorType = "FAIL_WITHOUT_RESPONSE";
-      const error = "some error message";
+      const error = new got.HTTPError(
+        {
+          body: { type: "SomeExceptionClass", message: "a detailed message" },
+          statusCode: 400,
+          statusMessage: "Bad request"
+        },
+        {}
+      );
 
       // then
       let thrownError;
 
       try {
-        await engineService.request("GET", "", { errorType, error });
+        await engineService.request("GET", "", { testResult: error });
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError).toEqual(new EngineError(error));
+    });
+
+    it("should throw error if request fails with other that HTTPError", async () => {
+      // given
+      const error = new got.RequestError(new Error("Some HTTP error"), {});
+
+      // then
+      let thrownError;
+
+      try {
+        await engineService.request("GET", "", { testResult: error });
       } catch (e) {
         thrownError = e;
       }
 
       expect(thrownError).toBe(error);
-    });
-
-    it("should throw error response if request fails with response", async () => {
-      // given
-      const errorType = "FAIL_WITHOUT_RESPONSE";
-      const error = {
-        response: {
-          body: { message: "Some error message" }
-        }
-      };
-
-      // then
-      let thrownError;
-
-      try {
-        await engineService.request("GET", "", { errorType, error });
-      } catch (e) {
-        thrownError = e;
-      }
-
-      expect(thrownError).toBe(error.response.body.message);
     });
   });
 });

--- a/lib/__internal/errors.js
+++ b/lib/__internal/errors.js
@@ -33,9 +33,16 @@ const MISSING_NEW_DURATION =
   "Couldn't extend lock time, no new duration was provided";
 
 // Basic Auth Interceptor
-const MISSING_AUTH_PARAMS =
+const MISSING_BASIC_AUTH_PARAMS =
   "Couldn't instantiate BasicAuthInterceptor, missing configuration parameter " +
   "'username' or 'password'";
+
+// Keycloak Auth Interceptor
+const MISSING_KEYCLOAK_AUTH_PARAMS =
+  "Couldn't instantiate KeycloakAuthInterceptor, missing configuration parameter " +
+  "'tokenEndpoint', 'clientId' or 'clientSecret'";
+const UNEXPECTED_KEYCLOAK_TOKEN_RESULT =
+  "Couldn't get access token from Keycloak provider; got";
 
 // FileService
 const MISSING_FILE_OPTIONS =
@@ -50,7 +57,9 @@ module.exports = {
   WRONG_INTERCEPTOR,
   MISSING_ERROR_CODE,
   MISSING_NEW_DURATION,
-  MISSING_AUTH_PARAMS,
+  MISSING_BASIC_AUTH_PARAMS,
+  MISSING_KEYCLOAK_AUTH_PARAMS,
+  UNEXPECTED_KEYCLOAK_TOKEN_RESULT,
   WRONG_MIDDLEWARES,
   MISSING_FILE_OPTIONS
 };

--- a/lib/__snapshots__/KeycloakAuthInterceptor.test.js.snap
+++ b/lib/__snapshots__/KeycloakAuthInterceptor.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KeycloakAuthInterceptor should add auth token to intercepted config 1`] = `
+Object {
+  "headers": Object {
+    "Authorization": "Bearer 1234567890",
+  },
+  "key": "some value",
+}
+`;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "chalk": "^2.3.2",
-    "got": "^8.2.0"
+    "got": "^10.6.0"
   },
   "description": "Implement your [BPMN Service Task](https://docs.camunda.org/manual/latest/user-guide/process-engine/external-tasks/) in NodeJS.",
   "bugs": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -103,10 +103,51 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@sindresorhus/is@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
-  integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
+"@sindresorhus/is@^2.0.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-2.1.0.tgz#6ad4ca610f696098e92954ab431ff83bea0ce13f"
+  integrity sha512-lXKXfypKo644k4Da4yXkPCrwcvn6SlUW2X2zFbuflKHNjf0w9htru01bo26uMhleMXsDmnZ12eJLdrAZa9MANg==
+
+"@szmarczak/http-timer@^4.0.0":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.5.tgz#bfbd50211e9dfa51ba07da58a14cdfd333205152"
+  integrity sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==
+  dependencies:
+    defer-to-connect "^2.0.0"
+
+"@types/cacheable-request@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
+  integrity sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==
+  dependencies:
+    "@types/http-cache-semantics" "*"
+    "@types/keyv" "*"
+    "@types/node" "*"
+    "@types/responselike" "*"
+
+"@types/http-cache-semantics@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
+  integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
+
+"@types/keyv@*":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.1.tgz#e45a45324fca9dab716ab1230ee249c9fb52cfa7"
+  integrity sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/node@*":
+  version "13.9.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.1.tgz#96f606f8cd67fb018847d9b61e93997dabdefc72"
+  integrity sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==
+
+"@types/responselike@*":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
+  integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
+  dependencies:
+    "@types/node" "*"
 
 abab@^2.0.0:
   version "2.0.3"
@@ -219,19 +260,6 @@ append-transform@^0.4.0:
   integrity sha1-126/jKlNJ24keja61EpLdKthGZE=
   dependencies:
     default-require-extensions "^1.0.0"
-
-aproba@^1.0.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
-  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
-
-are-we-there-yet@~1.1.2:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
-  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^2.0.6"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -637,18 +665,25 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-cacheable-request@^2.1.1:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-2.1.4.tgz#0d808801b6342ad33c91df9d0b44dc09b91e5c3d"
-  integrity sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=
+cacheable-lookup@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-2.0.0.tgz#33b1e56f17507f5cf9bb46075112d65473fb7713"
+  integrity sha512-s2piO6LvA7xnL1AR03wuEdSx3BZT3tIJpZ56/lcJwzO/6DTJZlTs7X3lrvPxk6d1PlDe6PrVe2TjlUIZNFglAQ==
   dependencies:
-    clone-response "1.0.2"
-    get-stream "3.0.0"
-    http-cache-semantics "3.8.1"
-    keyv "3.0.0"
-    lowercase-keys "1.0.0"
-    normalize-url "2.0.1"
-    responselike "1.0.2"
+    keyv "^4.0.0"
+
+cacheable-request@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.1.tgz#062031c2856232782ed694a257fa35da93942a58"
+  integrity sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^4.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^4.1.0"
+    responselike "^2.0.0"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -709,11 +744,6 @@ chardet@^0.4.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
   integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
 
-chownr@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
-  integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
-
 ci-info@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
@@ -755,7 +785,7 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
-clone-response@1.0.2:
+clone-response@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
   integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
@@ -824,11 +854,6 @@ concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-console-control-strings@^1.0.0, console-control-strings@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
-
 convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
@@ -895,7 +920,7 @@ debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -917,17 +942,12 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-decompress-response@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
-  integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
+decompress-response@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-5.0.0.tgz#7849396e80e3d1eba8cb2f75ef4930f76461cb0f"
+  integrity sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==
   dependencies:
-    mimic-response "^1.0.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+    mimic-response "^2.0.0"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -940,6 +960,11 @@ default-require-extensions@^1.0.0:
   integrity sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=
   dependencies:
     strip-bom "^2.0.0"
+
+defer-to-connect@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.0.tgz#83d6b199db041593ac84d781b5222308ccf4c2c1"
+  integrity sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==
 
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
@@ -975,22 +1000,12 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
   integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
   dependencies:
     repeating "^2.0.0"
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -1036,6 +1051,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+end-of-stream@^1.1.0:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
 
 error-ex@^1.2.0:
   version "1.3.2"
@@ -1542,21 +1564,6 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-from2@^2.1.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
-  integrity sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
-  dependencies:
-    inherits "^2.0.1"
-    readable-stream "^2.0.0"
-
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1580,20 +1587,6 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-gauge@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
-  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
-  dependencies:
-    aproba "^1.0.3"
-    console-control-strings "^1.0.0"
-    has-unicode "^2.0.0"
-    object-assign "^4.1.0"
-    signal-exit "^3.0.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wide-align "^1.1.0"
-
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
@@ -1604,10 +1597,17 @@ get-stdin@^5.0.1:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
   integrity sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=
 
-get-stream@3.0.0, get-stream@^3.0.0:
+get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
+
+get-stream@^5.0.0, get-stream@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
+  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
+  dependencies:
+    pump "^3.0.0"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -1658,28 +1658,26 @@ globals@^9.18.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
-got@^8.2.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/got/-/got-8.3.2.tgz#1d23f64390e97f776cac52e5b936e5f514d2e937"
-  integrity sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==
+got@^10.6.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/got/-/got-10.6.0.tgz#ac3876261a4d8e5fc4f81186f79955ce7b0501dc"
+  integrity sha512-3LIdJNTdCFbbJc+h/EH0V5lpNpbJ6Bfwykk21lcQvQsEcrzdi/ltCyQehFHLzJ/ka0UMH4Slg0hkYvAZN9qUDg==
   dependencies:
-    "@sindresorhus/is" "^0.7.0"
-    cacheable-request "^2.1.1"
-    decompress-response "^3.3.0"
+    "@sindresorhus/is" "^2.0.0"
+    "@szmarczak/http-timer" "^4.0.0"
+    "@types/cacheable-request" "^6.0.1"
+    cacheable-lookup "^2.0.0"
+    cacheable-request "^7.0.1"
+    decompress-response "^5.0.0"
     duplexer3 "^0.1.4"
-    get-stream "^3.0.0"
-    into-stream "^3.1.0"
-    is-retry-allowed "^1.1.0"
-    isurl "^1.0.0-alpha5"
-    lowercase-keys "^1.0.0"
-    mimic-response "^1.0.0"
-    p-cancelable "^0.4.0"
-    p-timeout "^2.0.1"
-    pify "^3.0.0"
-    safe-buffer "^5.1.1"
-    timed-out "^4.0.1"
-    url-parse-lax "^3.0.0"
-    url-to-options "^1.0.1"
+    get-stream "^5.0.0"
+    lowercase-keys "^2.0.0"
+    mimic-response "^2.1.0"
+    p-cancelable "^2.0.0"
+    p-event "^4.0.0"
+    responselike "^2.0.0"
+    to-readable-stream "^2.0.0"
+    type-fest "^0.10.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.2.3"
@@ -1732,27 +1730,10 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
-has-symbol-support-x@^1.4.1:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
-  integrity sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==
-
 has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
-
-has-to-string-tag-x@^1.2.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz#a045ab383d7b4b2012a00148ab0aa5f290044d4d"
-  integrity sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==
-  dependencies:
-    has-symbol-support-x "^1.4.1"
-
-has-unicode@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
-  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -1812,10 +1793,10 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
-http-cache-semantics@3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
-  integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
+http-cache-semantics@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
+  integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -1826,19 +1807,12 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.4:
+iconv-lite@0.4.24, iconv-lite@^0.4.17:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^3.3.3:
   version "3.3.10"
@@ -1866,15 +1840,10 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-ini@~1.3.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
 inquirer@^3.0.6:
   version "3.3.0"
@@ -1895,14 +1864,6 @@ inquirer@^3.0.6:
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
-
-into-stream@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
-  integrity sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=
-  dependencies:
-    from2 "^2.1.1"
-    p-is-promise "^1.1.0"
 
 invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.4"
@@ -2068,16 +2029,6 @@ is-number@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
   integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
 
-is-object@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
-  integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
-
-is-plain-obj@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
-  integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
-
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -2111,11 +2062,6 @@ is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
-
-is-retry-allowed@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
-  integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -2250,14 +2196,6 @@ istanbul-reports@^1.5.1:
   integrity sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==
   dependencies:
     handlebars "^4.0.3"
-
-isurl@^1.0.0-alpha5:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isurl/-/isurl-1.0.0.tgz#b27f4f49f3cdaa3ea44a0a5b7f3462e6edc39d67"
-  integrity sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==
-  dependencies:
-    has-to-string-tag-x "^1.2.0"
-    is-object "^1.0.1"
 
 jest-changed-files@^22.2.0:
   version "22.4.3"
@@ -2613,10 +2551,10 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-json-buffer@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
-  integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
@@ -2683,12 +2621,12 @@ jsx-ast-utils@^2.2.3:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
 
-keyv@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
-  integrity sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==
+keyv@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.0.0.tgz#2d1dab694926b2d427e4c74804a10850be44c12f"
+  integrity sha512-U7ioE8AimvRVLfw4LffyOIRhL2xVgmE8T22L6i0BucSnBUyv4w+I7VN/zVZwRKHOI6ZRUcdMdWHQ8KSUvGpEog==
   dependencies:
-    json-buffer "3.0.0"
+    json-buffer "3.0.1"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -2791,15 +2729,10 @@ loose-envify@^1.0.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lowercase-keys@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
-  integrity sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=
-
-lowercase-keys@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
-  integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
+lowercase-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
+  integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
 lru-cache@^4.0.1:
   version "4.1.5"
@@ -2912,6 +2845,11 @@ mimic-response@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
+mimic-response@^2.0.0, mimic-response@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
+  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+
 minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -2934,21 +2872,6 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
-
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
@@ -2957,7 +2880,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -3006,15 +2929,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 neo-async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
@@ -3035,22 +2949,6 @@ node-notifier@^5.2.1:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
-
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -3077,34 +2975,15 @@ normalize-path@^2.0.1, normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-url@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-2.0.1.tgz#835a9da1551fa26f70e92329069a23aa6574d7e6"
-  integrity sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==
-  dependencies:
-    prepend-http "^2.0.0"
-    query-string "^5.0.1"
-    sort-keys "^2.0.0"
+normalize-url@^4.1.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
+  integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
+npm-normalize-package-bin@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
   integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
-  integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -3112,16 +2991,6 @@ npm-run-path@^2.0.0:
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
-
-npmlog@^4.0.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -3232,7 +3101,7 @@ object.values@^1.1.0:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -3293,20 +3162,22 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
-p-cancelable@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.4.1.tgz#35f363d67d52081c8d9585e37bcceb7e0bbcb2a0"
-  integrity sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==
+p-cancelable@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.0.0.tgz#4a3740f5bdaf5ed5d7c3e34882c6fb5d6b266a6e"
+  integrity sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==
+
+p-event@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-event/-/p-event-4.1.0.tgz#e92bb866d7e8e5b732293b1c8269d38e9982bf8e"
+  integrity sha512-4vAd06GCsgflX4wHN1JqrMzBh/8QZ4j+rzp0cd2scXRwuBEv+QR3wrVA5aLhWDLw4y2WgDKvzWF3CCLmVM1UgA==
+  dependencies:
+    p-timeout "^2.0.1"
 
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
-
-p-is-promise@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
-  integrity sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -3412,11 +3283,6 @@ pify@^2.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
 
-pify@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
-  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
-
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -3455,11 +3321,6 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
-
-prepend-http@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
-  integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
 preserve@^0.2.0:
   version "0.2.0"
@@ -3513,6 +3374,14 @@ psl@^1.1.24, psl@^1.1.28:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.7.0.tgz#f1c4c47a8ef97167dea5d6bbf4816d736e884a3c"
   integrity sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==
 
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -3528,15 +3397,6 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-query-string@^5.0.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
-  integrity sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    object-assign "^4.1.0"
-    strict-uri-encode "^1.0.0"
-
 ramda@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
@@ -3550,16 +3410,6 @@ randomatic@^3.0.0:
     is-number "^4.0.0"
     kind-of "^6.0.0"
     math-random "^1.0.1"
-
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
 
 react-is@^16.8.1:
   version "16.12.0"
@@ -3609,7 +3459,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.2.2:
+readable-stream@^2.0.1, readable-stream@^2.2.2:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -3785,12 +3635,12 @@ resolve@^1.10.0, resolve@^1.13.1:
   dependencies:
     path-parse "^1.0.6"
 
-responselike@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
-  integrity sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
+responselike@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.0.tgz#26391bcc3174f750f9a79eacc40a12a5c42d7723"
+  integrity sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==
   dependencies:
-    lowercase-keys "^1.0.0"
+    lowercase-keys "^2.0.0"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -3843,7 +3693,7 @@ rx-lite@*, rx-lite@^4.0.8:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
   integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2:
+safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
@@ -3891,7 +3741,7 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -3974,13 +3824,6 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
-
-sort-keys@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
-  integrity sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=
-  dependencies:
-    is-plain-obj "^1.0.0"
 
 source-map-resolve@^0.5.0:
   version "0.5.3"
@@ -4117,11 +3960,6 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
-strict-uri-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-  integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
-
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -4139,7 +3977,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
+string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -4242,19 +4080,6 @@ table@4.0.2:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
-
 test-exclude@^4.2.1:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.3.tgz#a9a5e64474e4398339245a0a769ad7c2f4a97c20"
@@ -4280,11 +4105,6 @@ through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
-
-timed-out@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
-  integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -4314,6 +4134,11 @@ to-object-path@^0.3.0:
   integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
   dependencies:
     kind-of "^3.0.2"
+
+to-readable-stream@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-2.1.0.tgz#82880316121bea662cdc226adb30addb50cb06e8"
+  integrity sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==
 
 to-regex-range@^2.1.0:
   version "2.1.1"
@@ -4385,6 +4210,11 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-fest@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.10.0.tgz#7f06b2b9fbfc581068d1341ffabd0349ceafc642"
+  integrity sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -4427,18 +4257,6 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
-
-url-parse-lax@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
-  integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
-  dependencies:
-    prepend-http "^2.0.0"
-
-url-to-options@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
-  integrity sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=
 
 use@^3.1.0:
   version "3.1.1"
@@ -4554,13 +4372,6 @@ which@^1.2.12, which@^1.2.9, which@^1.3.0:
   dependencies:
     isexe "^2.0.0"
 
-wide-align@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
-  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
-  dependencies:
-    string-width "^1.0.2 || 2"
-
 word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
@@ -4621,11 +4432,6 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
-
-yallist@^3.0.0, yallist@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
-  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yargs-parser@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
[![CAM-11670](https://badgen.net/badge/JIRA/CAM-11670/0052CC)](https://app.camunda.com/jira/browse/CAM-11670)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This pull request adds a KeycloakAuthInterceptor on top of `got` hooks. Hooks
are supported since version 9 of `got` and they allow to use async functions
to manipulate the request. This pull request adds this functionality without
loosing backward compatibility. It also serves as an example of how authentication
against third party authentication providers can be implemented with hooks.

The complete code was updated to work with the latest version of `got`. The new
functionality is covered with tests.