### PR TITLE
CAM-11735 - support localVariables

### DIFF
--- a/docs/Client.md
+++ b/docs/Client.md
@@ -75,6 +75,8 @@ The currently supported options are:
 | processVariables  | A JSON object used for filtering tasks based on process instance variable values. A property name of the object represents a process variable name, while the property value represents the process variable value to filter tasks by.         | object |          |                                                       |
 | tenantIdIn | A value which allows to filter tasks based on tenant ids         | string |          |                                                       |
 | withoutTenantId | A value which allows to filter tasks without tenant id                              | boolean |         |                                                       |
+| localVariables | A value which allow to fetch only local variables     | boolean |          |                                                       |
+
 
 
 ### About topic subscriptions

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -195,7 +195,9 @@ class Client extends events {
           processDefinitionVersionTag,
           processVariables,
           tenantIdIn,
-          withoutTenantId
+          withoutTenantId,
+          localVariables,
+          deserializeValues
         }
       ]) => {
         let topic = { topicName, lockDuration };
@@ -238,6 +240,14 @@ class Client extends events {
 
         if (!isUndefinedOrNull(withoutTenantId)) {
           topic.withoutTenantId = withoutTenantId;
+        }
+
+        if (!isUndefinedOrNull(localVariables)) {
+          topic.localVariables = localVariables;
+        }
+
+        if (!isUndefinedOrNull(deserializeValues)) {
+          topic.deserializeValues = deserializeValues;
         }
 
         return topic;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -196,8 +196,7 @@ class Client extends events {
           processVariables,
           tenantIdIn,
           withoutTenantId,
-          localVariables,
-          deserializeValues
+          localVariables
         }
       ]) => {
         let topic = { topicName, lockDuration };
@@ -244,10 +243,6 @@ class Client extends events {
 
         if (!isUndefinedOrNull(localVariables)) {
           topic.localVariables = localVariables;
-        }
-
-        if (!isUndefinedOrNull(deserializeValues)) {
-          topic.deserializeValues = deserializeValues;
         }
 
         return topic;

--- a/lib/Client.test.js
+++ b/lib/Client.test.js
@@ -227,7 +227,8 @@ describe("Client", () => {
         processDefinitionKeyIn: ["processKey", "processKey2"],
         processDefinitionVersionTag: "versionTag",
         tenantIdIn: ["tenantId"],
-        withoutTenantId: true
+        withoutTenantId: true,
+        localVariables: true
       };
     });
 
@@ -357,6 +358,19 @@ describe("Client", () => {
       // then
       expect(footopicSubscription.withoutTenantId).toBe(
         customConfig.withoutTenantId
+      );
+    });
+
+    test("should subscribe to topic based on localVariables ", () => {
+      // given
+      const footopicSubscription = client.subscribe(
+        "foo",
+        customConfig,
+        fooWork
+      );
+      // then
+      expect(footopicSubscription.localVariables).toBe(
+        customConfig.localVariables
       );
     });
 

--- a/lib/__snapshots__/Client.test.js.snap
+++ b/lib/__snapshots__/Client.test.js.snap
@@ -27,6 +27,7 @@ Array [
     "maxTasks": 3,
     "topics": Array [
       Object {
+        "localVariables": true,
         "lockDuration": 3000,
         "processDefinitionId": "processId",
         "processDefinitionIdIn": Array [


### PR DESCRIPTION
[![](https://badgen.net/badge/JIRA//0052CC)](https://app.camunda.com/jira/browse/)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

i just added `localVariables`  to `customOptions` argument in `subscribe()` func   which supported in rest [POST /external-task/fetchAndLock](https://docs.camunda.org/manual/7.10/reference/rest/external-task/fetch/) `camunda v7.10`       

you will need to update  SubscribeOptions interface in [@types/camunda-external-task-client-js](https://www.npmjs.com/package/@types/camunda-external-task-client-js)