### PR TITLE
[CAM-13978]: add support transient Variables

### DIFF
--- a/docs/Variables.md
+++ b/docs/Variables.md
@@ -130,6 +130,27 @@ Output:
 }
 ```
 
+## `variables.setTransient(variableName, value)`
+
+Sets a value for the variable with key _variableName_, also sets transient flag true to variable.
+
+> **Note:** The variable type is determined automatically.
+
+```js
+variables.setTransient("fullName", { first: "John", last: "Doe" });
+console.log(variables.getTyped("fullName"));
+```
+
+Output:
+
+```js
+{
+      value: { first: "John", last: "Doe" },
+      type:  "json",
+      valueInfo: {transient: true}
+}
+```
+
 ## `variables.setTyped(variableName, typedValue)`
 
 Sets a typed value for the variable with key _variableName_

--- a/lib/Variables.js
+++ b/lib/Variables.js
@@ -102,6 +102,18 @@ function Variables(initialVariables = {}, options = {}) {
     };
 
     /**
+     * Sets value for variable corresponding to variableName
+     * The type is determined automatically
+     * The variable has transient flag: true
+     * @param variableName
+     * @param value
+     */
+    this.setTransient = (variableName, value) => {
+      const type = getVariableType(value);
+      return this.setTyped(variableName, { type, value, valueInfo: {transient: true} });
+    };
+
+    /**
      * Sets the values of multiple variables at once
      * The new values are merged with existing ones
      * @param values

--- a/lib/Variables.js
+++ b/lib/Variables.js
@@ -110,7 +110,11 @@ function Variables(initialVariables = {}, options = {}) {
      */
     this.setTransient = (variableName, value) => {
       const type = getVariableType(value);
-      return this.setTyped(variableName, { type, value, valueInfo: {transient: true} });
+      return this.setTyped(variableName, {
+        type,
+        value,
+        valueInfo: { transient: true }
+      });
     };
 
     /**

--- a/lib/Variables.test.js
+++ b/lib/Variables.test.js
@@ -143,6 +143,17 @@ describe("Variables", () => {
       expect(variables.getDirtyVariables()).toMatchSnapshot("dirty variables");
     });
 
+    it('setTransient("fooTransient", "fooValueTransient")) should set variable with key "fooTransient" and value "fooValueTransient" and transient "true"', () => {
+      // given
+      expect(variables.getAllTyped()).toMatchSnapshot("variables");
+      expect(variables.getDirtyVariables()).toMatchSnapshot("dirty variables");
+      variables.setTransient("fooTransient", "fooValueTransient");
+
+      // then
+      expect(variables.getAllTyped()).toMatchSnapshot("variables");
+      expect(variables.getDirtyVariables()).toMatchSnapshot("dirty variables");
+    });
+
     it("setAll(someValues)  should add someValues to variables", () => {
       // given
       expect(variables.getAllTyped()).toMatchSnapshot("variables");

--- a/lib/__snapshots__/Variables.test.js.snap
+++ b/lib/__snapshots__/Variables.test.js.snap
@@ -115,6 +115,7 @@ Array [
   "getDirtyVariables",
   "setTyped",
   "set",
+  "setTransient",
   "setAll",
   "setAllTyped",
 ]
@@ -150,6 +151,34 @@ Object {
     "type": "string",
     "value": "fooValue",
     "valueInfo": Object {},
+  },
+}
+`;
+
+exports[`Variables setters setTransient("fooTransient", "fooValueTransient")) should set variable with key "fooTransient" and value "fooValueTransient" and transient "true": dirty variables 1`] = `Object {}`;
+
+exports[`Variables setters setTransient("fooTransient", "fooValueTransient")) should set variable with key "fooTransient" and value "fooValueTransient" and transient "true": dirty variables 2`] = `
+Object {
+  "fooTransient": Object {
+    "type": "string",
+    "value": "fooValueTransient",
+    "valueInfo": Object {
+      "transient": true,
+    },
+  },
+}
+`;
+
+exports[`Variables setters setTransient("fooTransient", "fooValueTransient")) should set variable with key "fooTransient" and value "fooValueTransient" and transient "true": variables 1`] = `Object {}`;
+
+exports[`Variables setters setTransient("fooTransient", "fooValueTransient")) should set variable with key "fooTransient" and value "fooValueTransient" and transient "true": variables 2`] = `
+Object {
+  "fooTransient": Object {
+    "type": "string",
+    "value": "fooValueTransient",
+    "valueInfo": Object {
+      "transient": true,
+    },
   },
 }
 `;


### PR DESCRIPTION
there is support of transient flag in rest api, but is hard to define it in current client
right now I use
```
service.localVariables.setTyped('result', { type: getVariableType(result), value: result, valueInfo: {transient: true}});
```

but getVariableType is internal method and is not available in definitions in /__internal/utils.js
