### PR TITLE
Changed the check for content-type json to allow for charsets to be s…

### DIFF
--- a/lib/__internal/EngineService.js
+++ b/lib/__internal/EngineService.js
@@ -51,7 +51,10 @@ class EngineService {
         ...newOptions,
         responseType: "buffer"
       });
-      if (headers["content-type"] === "application/json") {
+      if (
+        headers["content-type"] &&
+        headers["content-type"].substring(0, 16) === "application/json"
+      ) {
         return JSON.parse(body.toString("utf-8"));
       } else {
         return body;


### PR DESCRIPTION
Current code does not allow for proper header settings in the Content-Type. If Content-Type is set to "application/json; charset=utf-8" the task will not be properly forwarded to the handler callback. By changing the code to only check the start o the Content-Type we accept any charsets that are send.