### PR TITLE
docs(client): remove wrong default configuration descripttion

### DIFF
--- a/docs/Client.md
+++ b/docs/Client.md
@@ -73,7 +73,7 @@ The currently supported options are:
 | Option       | Description                                                                         | Type   | Required | Default                                               |
 |--------------|-------------------------------------------------------------------------------------|--------|----------|-------------------------------------------------------|
 | lockDuration | specifies the lock duration for this specific handler.                              | number |          | global lockDuration configured in the client instance |
-| variables    | defines a subset of variables available in the handler.                             | array  |          | global lockDuration configured in the client instance |
+| variables    | defines a subset of variables available in the handler.                             | array  |          |                                                       |
 | businessKey  | A value which allows to filter tasks based on process instance business key         | string |          |                                                       |
 | processDefinitionId  | A value which allows to filter tasks based on process definition id         | string |          |                                                       |
 | processDefinitionIdIn  | A value which allows to filter tasks based on process definition ids         | string |          |                                                       |


### PR DESCRIPTION
Only true for `lockDuration`.